### PR TITLE
🔧 READMEファイルのヘッダー画像パス修正とMarkdownLint設定の改善

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,6 +6,7 @@
     "allowed_elements": [
       "a",
       "details",
+      "h1",
       "i",
       "img",
       "p",

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align="center">
   <a href="">
-    <img src="./header.jpg" alt="header" width="100%">
+    <img src="./docs/header.jpg" alt="header" width="100%">
   </a>
   <h1 align="center">Renovate Config</h1>
 </p>

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <a href="">
-    <img src="./docs/header.jpg" alt="header" width="100%">
+    <img src="./header.jpg" alt="header" width="100%">
   </a>
-  <span align="center" style="font-size: 4rem;">Renovate Config</span>
+  <h1 align="center">Renovate Config</h1>
 </p>
 
 <p align="center">

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -2,7 +2,7 @@
   <a href="">
     <img src="./header.jpg" alt="header" width="100%">
   </a>
-  <span align="center" style="font-size: 4rem;">Renovate Config</span>
+  <h1 align="center">Renovate Config</h1>
 </p>
 
 <p align="center">


### PR DESCRIPTION

## 📒 変更点の概要

- `README.md`と`docs/README.ja.md`のヘッダー画像のパスを修正しました。
  - 画像パスを`./header.jpg`から`./docs/header.jpg`に変更しました。
- `README.md`と`docs/README.ja.md`のヘッダー部分のテキストを`<span>`から`<h1>`タグに変更しました。
- `.markdownlint.json`に`h1`要素を許可する設定を追加しました。

## ⚒ 技術的な詳細

- `README.md`と`docs/README.ja.md`の変更により、ヘッダー画像のパスが正しく設定され、画像が表示されるようになりました。
- `<span>`タグを`<h1>`タグに変更することで、MarkdownLintのルールに従った適切な見出し構造を持つようになりました。
- `.markdownlint.json`に`h1`を追加することで、MarkdownLintが`h1`タグを許可し、エラーを防ぐ設定が行われました。

## ⚠ 注意点

- 画像パスの変更により、`docs`ディレクトリ内に`header.jpg`が存在することを確認してください。存在しない場合、画像が表示されません。