### PR TITLE
🔧 GitHub Actionsワークフローの改善とライセンス表記の修正

### DIFF
--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -1,0 +1,28 @@
+---
+name: Update License Year
+
+on:
+  schedule:
+    - cron: "0 0 1 1 *"  # 毎年1月1日に実行
+  workflow_dispatch:
+
+jobs:
+  commit-changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write # git push するために必要
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Generate GitHub App Token
+        id: app_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GHA_APP_ID }}
+          private-key: ${{ secrets.GHA_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - uses: tqer39/update-license-year@v0.0.1-alpha
+        with:
+          github-token: ${{ steps.app_token.outputs.token }}

--- a/.github/workflows/update-license-year.yml
+++ b/.github/workflows/update-license-year.yml
@@ -3,7 +3,7 @@ name: Update License Year
 
 on:
   schedule:
-    - cron: "0 0 1 1 *"  # 毎年1月1日に実行
+    - cron: '0 0 1 1 *' # 毎年1月1日に実行
   workflow_dispatch:
 
 jobs:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,7 @@ repos:
       - id: prettier
         name: Format GitHub Actions workflow files
         types:
+          - json
           - yaml
 
   - repo: https://github.com/rhysd/actionlint

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 t.ooyama
+Copyright (c) 2022 Takeru O'oyama
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/cspell.json
+++ b/cspell.json
@@ -36,6 +36,7 @@
     "moto",
     "mypy",
     "nodenv",
+    "O'oyama",
     "ooyama",
     "powertools",
     "pyenv",
@@ -46,6 +47,7 @@
     "setuptools",
     "shellcheck",
     "SSIA",
+    "Takeru",
     "textlint",
     "textlintcache",
     "tqer"


### PR DESCRIPTION

## 📒 変更点の概要

- `.pre-commit-config.yaml`において、GitHub Actionsワークフローファイルのフォーマット対象にJSONを追加しました。
- `.github/workflows/update-license-year.yml`のcronスケジュール設定のフォーマットを改善しました。
- `LICENSE`ファイルの著作権表記を修正し、スペルチェック用の辞書に名前を追加しました。
- ライセンス年を更新するためのGitHub Actionsワークフローを新規に追加しました。

## ⚒ 技術的な詳細

- **JSONフォーマットの追加**: `.pre-commit-config.yaml`で、GitHub Actionsワークフローファイルのフォーマット対象にJSONを追加することで、JSONファイルのフォーマットも自動化されるようになりました。
- **cronスケジュールのフォーマット改善**: `.github/workflows/update-license-year.yml`のcronスケジュールのクォートをダブルクォートからシングルクォートに変更しました。これにより、フォーマットが統一され、可読性が向上しました。
- **著作権表記の修正**: `LICENSE`ファイルの著作権者名を「t.ooyama」から「Takeru O'oyama」に修正しました。また、スペルチェック用の辞書に「O'oyama」と「Takeru」を追加しました。
- **新規ワークフローの追加**: ライセンス年を毎年1月1日に自動更新するGitHub Actionsワークフローを追加しました。このワークフローは、GitHub App Tokenを生成し、`tqer39/update-license-year`アクションを使用してライセンス年を更新します。

## ⚠ 注意点

- **GitHub Secretsの設定**: 新しいワークフローでは、GitHub App Tokenを生成するために`GHA_APP_ID`と`GHA_APP_PRIVATE_KEY`のシークレットが必要です。これらのシークレットが正しく設定されていることを確認してください。