### PR TITLE
🔧 GitHub ActionsのPR作成者チェック条件を改善

### DIFF
--- a/.github/workflows/generate-pr-description.yml
+++ b/.github/workflows/generate-pr-description.yml
@@ -16,7 +16,7 @@ jobs:
     permissions:
       pull-requests: write # uses: tqer39/generate-pr-description-action
     # Check if the PR is not created by 'renovate' or 'tqer39-apps'
-    if: github.event.pull_request.user.login != 'renovate' && github.event.pull_request.user.login != 'tqer39-apps'
+    if: contains(fromJSON('["renovate[bot]", "tqer39-apps[bot]"]'), github.event.pull_request.user.login) == false
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION

## 📒 変更点の概要

- GitHub Actionsのワークフローファイル `generate-pr-description.yml` において、PR作成者のチェック条件を改善しました。

## ⚒ 技術的な詳細

- PR作成者が特定のボット（`renovate[bot]` や `tqer39-apps[bot]`）でないことを確認する条件を変更しました。
  - 以前は、`github.event.pull_request.user.login` が `'renovate'` または `'tqer39-apps'` でないことを直接比較していました。
  - 新しい条件では、`fromJSON` 関数を使用してボットのリストを配列として定義し、`contains` 関数でPR作成者がこのリストに含まれていないことを確認しています。

## ⚠ 注意点

- この変更により、ボットアカウントの名前が正確に一致する必要があります。名前の変更や新しいボットの追加があった場合は、リストの更新が必要です。