### PR TITLE
🔄 Update Configuration File Extensions to .json5 in Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,24 +70,24 @@ The configuration file cannot be placed anywhere other than the root of the repo
 
 | File Name | Description |
 |-----------|-------------|
-| [automergeGitHubActions.json](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for GitHub Actions |
-| [automergeNodeEnv.json](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for the Node.js environment |
-| [automergePreCommit.json](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for pre-commit |
-| [automergePyEnv.json](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for pyenv |
-| [automergePython.json](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for Python packages |
-| [automergeSchedule.json](https://docs.renovatebot.com/configuration-options/#schedule) | Schedule settings for auto-merging |
-| [automergeStrategy.json](https://docs.renovatebot.com/configuration-options/#automerge) | Strategy settings for auto-merging |
-| [dependencyDashboard.json](https://docs.renovatebot.com/configuration-options/#dependencydashboard) | Settings for the dependency dashboard |
-| [major.json](https://docs.renovatebot.com/configuration-options/#major) | Settings for major updates |
-| [minor.json](https://docs.renovatebot.com/configuration-options/#minor) | Settings for minor updates |
-| [patch.json](https://docs.renovatebot.com/configuration-options/#patch) | Settings for patch updates |
-| [platformAutomerge.json](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for platforms |
-| [prHourlyLimit.json](https://docs.renovatebot.com/configuration-options/#prhourlylimit) | Hourly limit settings for pull requests |
-| [schedule.json](https://docs.renovatebot.com/configuration-options/#schedule) | Schedule settings |
-| [separateMajorMinor.json](https://docs.renovatebot.com/configuration-options/#separatemajorminor) | Settings for separating major and minor updates |
-| [separateMultipleMajor.json](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor) | Settings for separating multiple major updates |
-| [timezone.json](https://docs.renovatebot.com/configuration-options/#timezone) | Time zone settings |
-| [vulnerabilityAlerts.json](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts) | Vulnerability alert settings. This enables notifications if vulnerabilities are detected in dependencies. |
+| [automergeGitHubActions.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for GitHub Actions |
+| [automergeNodeEnv.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for the Node.js environment |
+| [automergePreCommit.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for pre-commit |
+| [automergePyEnv.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for pyenv |
+| [automergePython.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for Python packages |
+| [automergeSchedule.json5](https://docs.renovatebot.com/configuration-options/#schedule) | Schedule settings for auto-merging |
+| [automergeStrategy.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Strategy settings for auto-merging |
+| [dependencyDashboard.json5](https://docs.renovatebot.com/configuration-options/#dependencydashboard) | Settings for the dependency dashboard |
+| [major.json5](https://docs.renovatebot.com/configuration-options/#major) | Settings for major updates |
+| [minor.json5](https://docs.renovatebot.com/configuration-options/#minor) | Settings for minor updates |
+| [patch.json5](https://docs.renovatebot.com/configuration-options/#patch) | Settings for patch updates |
+| [platformAutomerge.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for platforms |
+| [prHourlyLimit.json5](https://docs.renovatebot.com/configuration-options/#prhourlylimit) | Hourly limit settings for pull requests |
+| [schedule.json5](https://docs.renovatebot.com/configuration-options/#schedule) | Schedule settings |
+| [separateMajorMinor.json5](https://docs.renovatebot.com/configuration-options/#separatemajorminor) | Settings for separating major and minor updates |
+| [separateMultipleMajor.json5](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor) | Settings for separating multiple major updates |
+| [timezone.json5](https://docs.renovatebot.com/configuration-options/#timezone) | Time zone settings |
+| [vulnerabilityAlerts.json5](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts) | Vulnerability alert settings. This enables notifications if vulnerabilities are detected in dependencies. |
 
 ## Contribution
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -68,24 +68,24 @@ sequenceDiagram
 
 | ファイル名 | 説明 |
 |------------|------|
-| [automergeGitHubActions.json](https://docs.renovatebot.com/configuration-options/#automerge) | GitHub Actions の自動マージ設定 |
-| [automergeNodeEnv.json](https://docs.renovatebot.com/configuration-options/#automerge) | Node.js 環境の自動マージ設定 |
-| [automergePreCommit.json](https://docs.renovatebot.com/configuration-options/#automerge) | pre-commit の自動マージ設定 |
-| [automergePyEnv.json](https://docs.renovatebot.com/configuration-options/#automerge) | pyenv の自動マージ設定 |
-| [automergePython.json](https://docs.renovatebot.com/configuration-options/#automerge) | Python パッケージの自動マージ設定 |
-| [automergeSchedule.json](https://docs.renovatebot.com/configuration-options/#schedule) | 自動マージのスケジュール設定 |
-| [automergeStrategy.json](https://docs.renovatebot.com/configuration-options/#automerge) | 自動マージの戦略設定 |
-| [dependencyDashboard.json](https://docs.renovatebot.com/configuration-options/#dependencydashboard) | 依存関係ダッシュボードの設定 |
-| [major.json](https://docs.renovatebot.com/configuration-options/#major) | メジャーアップデートの設定 |
-| [minor.json](https://docs.renovatebot.com/configuration-options/#minor) | マイナーアップデートの設定 |
-| [patch.json](https://docs.renovatebot.com/configuration-options/#patch) | パッチアップデートの設定 |
-| [platformAutomerge.json](https://docs.renovatebot.com/configuration-options/#automerge) | プラットフォームの自動マージ設定 |
-| [prHourlyLimit.json](https://docs.renovatebot.com/configuration-options/#prhourlylimit) | プルリクエストの時間あたりの制限設定 |
-| [schedule.json](https://docs.renovatebot.com/configuration-options/#schedule) | スケジュール設定 |
-| [separateMajorMinor.json](https://docs.renovatebot.com/configuration-options/#separatemajorminor) | メジャーとマイナーの分離設定 |
-| [separateMultipleMajor.json](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor) | 複数のメジャーアップデートの分離設定 |
-| [timezone.json](https://docs.renovatebot.com/configuration-options/#timezone) | タイムゾーンの設定 |
-| [vulnerabilityAlerts.json](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts) | 脆弱性アラートの設定。これにより、依存関係に脆弱性が発見された場合に通知を受け取ることができます。 |
+| [automergeGitHubActions.json5](https://docs.renovatebot.com/configuration-options/#automerge) | GitHub Actions の自動マージ設定 |
+| [automergeNodeEnv.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Node.js 環境の自動マージ設定 |
+| [automergePreCommit.json5](https://docs.renovatebot.com/configuration-options/#automerge) | pre-commit の自動マージ設定 |
+| [automergePyEnv.json5](https://docs.renovatebot.com/configuration-options/#automerge) | pyenv の自動マージ設定 |
+| [automergePython.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Python パッケージの自動マージ設定 |
+| [automergeSchedule.json5](https://docs.renovatebot.com/configuration-options/#schedule) | 自動マージのスケジュール設定 |
+| [automergeStrategy.json5](https://docs.renovatebot.com/configuration-options/#automerge) | 自動マージの戦略設定 |
+| [dependencyDashboard.json5](https://docs.renovatebot.com/configuration-options/#dependencydashboard) | 依存関係ダッシュボードの設定 |
+| [major.json5](https://docs.renovatebot.com/configuration-options/#major) | メジャーアップデートの設定 |
+| [minor.json5](https://docs.renovatebot.com/configuration-options/#minor) | マイナーアップデートの設定 |
+| [patch.json5](https://docs.renovatebot.com/configuration-options/#patch) | パッチアップデートの設定 |
+| [platformAutomerge.json5](https://docs.renovatebot.com/configuration-options/#automerge) | プラットフォームの自動マージ設定 |
+| [prHourlyLimit.json5](https://docs.renovatebot.com/configuration-options/#prhourlylimit) | プルリクエストの時間あたりの制限設定 |
+| [schedule.json5](https://docs.renovatebot.com/configuration-options/#schedule) | スケジュール設定 |
+| [separateMajorMinor.json5](https://docs.renovatebot.com/configuration-options/#separatemajorminor) | メジャーとマイナーの分離設定 |
+| [separateMultipleMajor.json5](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor) | 複数のメジャーアップデートの分離設定 |
+| [timezone.json5](https://docs.renovatebot.com/configuration-options/#timezone) | タイムゾーンの設定 |
+| [vulnerabilityAlerts.json5](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts) | 脆弱性アラートの設定。これにより、依存関係に脆弱性が発見された場合に通知を受け取ることができます。 |
 
 ## 貢献方法
 


### PR DESCRIPTION

## 📒 変更点の概要

- `README.ja.md` と `README.md` の設定ファイル名を `.json` から `.json5` に変更しました。

## ⚒ 技術的な詳細

- 設定ファイルの拡張子を `.json5` に変更することで、JSON5 の機能を利用できるようになります。JSON5 は、コメントの追加やトレーリングコンマの許可など、JSON よりも柔軟な記述が可能です。

## ⚠ 注意点

> [!NOTE]
>
> - この変更はドキュメント内のファイル名の更新に限られており、実際の設定ファイルの内容や機能には影響を与えません。