### PR TITLE
🔧 Remove 'dependencies' label from `labels.json5`

### DIFF
--- a/labels.json5
+++ b/labels.json5
@@ -1,7 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "labels": [
-    "dependencies",
     "renovate"
   ]
 }


### PR DESCRIPTION

## 📒 変更点の概要

- `labels.json5` ファイルから "dependencies" ラベルが削除されました。

## ⚒ 技術的な詳細

- `labels.json5` は Renovate Bot の設定ファイルであり、ラベルの管理に使用されます。
- 今回の変更により、"dependencies" ラベルが削除され、現在は "renovate" ラベルのみが残っています。

## ⚠ 注意点

- この変更により、"dependencies" ラベルを使用していたワークフローやフィルタリングが影響を受ける可能性があります。必要に応じて、設定やドキュメントを更新してください。