### PR TITLE
🚀 textlintの依存関係とルール設定の改善

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,12 +48,10 @@ repos:
         entry: textlint
         require_serial: false
         additional_dependencies:
-          - 'textlint@15.2.2'
-          - 'textlint-filter-rule-allowlist@4.0.0'
-          - 'textlint-rule-ja-no-space-between-full-width@2.4.2'
-          - 'textlint-filter-rule-comments@1.2.2'
-          - 'textlint-rule-no-dropping-the-ra@3.0.0'
-          - 'textlint-rule-terminology@5.2.16'
+          - 'textlint@15.5.1'
+          - 'textlint-filter-rule-comments@1.3.0'
+          - 'textlint-rule-preset-smarthr@1.36.1'
+          - 'textlint-rule-preset-ja-technical-writing@12.0.2'
 
   - repo: https://github.com/koalaman/shellcheck-precommit
     rev: v0.11.0

--- a/.textlintrc
+++ b/.textlintrc
@@ -3,7 +3,35 @@
     "comments": true
   },
   "rules": {
-    "no-dropping-the-ra": true,
-    "ja-no-space-between-full-width": true
+    "preset-smarthr": {
+      "sentence-length": {
+        "max": 150
+      },
+      "ja-no-mixed-period": {
+        "allowPeriodMarks": [":", "：", "）", ")", "」", "】", "》", "〉", ">", "✅", "⚠️"],
+        "allowEmojiAtEnd": true,
+        "forceAppendPeriod": false
+      },
+      "prh-rules": false,
+      "ja-no-space-between-full-width": false,
+      "ja-space-between-half-and-full-width": false,
+      "ja-hiragana-fukushi": false
+    },
+    "preset-ja-technical-writing": {
+      "no-mix-dearu-desumasu": {
+        "preferInHeader": "",
+        "preferInBody": "ですます",
+        "preferInList": "",
+        "strict": false
+      },
+      "sentence-length": false,
+      "no-dropping-the-ra": false,
+      "no-double-negative-ja": false,
+      "ja-no-redundant-expression": false,
+      "ja-no-abusage": false,
+      "no-doubled-conjunctive-particle-ga": false,
+      "ja-no-mixed-period": false,
+      "no-exclamation-question-mark": false
+    }
   }
 }


### PR DESCRIPTION

## 📒 変更概要

- `textlint`の依存関係を更新し、バージョンを`15.5.1`にアップデートしました。
- ルール設定を改善し、新たに`textlint-rule-preset-smarthr`と`textlint-rule-preset-ja-technical-writing`を追加しました。

## ⚒ 技術的詳細

- `.pre-commit-config.yaml`ファイルで、以下の依存関係を更新しました:
  - `textlint`を`15.5.1`に更新
  - `textlint-filter-rule-comments`を`1.3.0`に更新
  - `textlint-rule-preset-smarthr`を`1.36.1`に追加
  - `textlint-rule-preset-ja-technical-writing`を`12.0.2`に追加
- `.textlintrc`ファイルで、以下のルール設定を改善しました:
  - `preset-smarthr`のルールを追加し、文の長さや句読点の使用に関する設定を行いました。
  - `preset-ja-technical-writing`のルールを追加し、文体や表現の一貫性を確保するための設定を行いました。

## ⚠ 注意点

- 💡 新しいルール設定により、既存の文章がルール違反と判定される可能性があります。文章の修正が必要な場合がありますのでご注意ください。