### PR TITLE
🔧 markdownlint-cliの更新と--fixオプションの追加

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,10 +33,11 @@ repos:
       - id: cspell
 
   # see: https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
-  - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.45.0
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.17.2
     hooks:
-      - id: markdownlint
+      - id: markdownlint-cli2
+        args: ['--fix']
 
   - repo: local
     hooks:


### PR DESCRIPTION

## 📒 変更概要

- 🔄 `markdownlint-cli`を`markdownlint-cli2`に更新しました。
- 🛠 `--fix`オプションを追加し、Markdownファイルの自動修正を可能にしました。

## ⚒ 技術的詳細

- 📌 `.pre-commit-config.yaml`ファイル内で、`markdownlint-cli`のリポジトリを`https://github.com/igorshubovych/markdownlint-cli`から`https://github.com/DavidAnson/markdownlint-cli2`に変更しました。
- 📌 バージョンを`v0.45.0`から`v0.17.2`に更新しました。
- 📌 `markdownlint`のフックIDを`markdownlint-cli2`に変更し、`args`に`['--fix']`を追加しました。

## ⚠ 注意点

- 💡 `--fix`オプションを使用することで、Markdownファイルのスタイルが自動的に修正されるため、コミット前に変更内容を確認することをお勧めします。