### PR TITLE
🚀 READMEファイルの自動マージ設定情報を更新し、主要な設定項目を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,25 +69,24 @@ sequenceDiagram
 The configuration file cannot be placed anywhere other than the root of the repository.
 
 | File Name | Description |
-| ----------- | ------------- |
-| [automergeGitHubActions.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for GitHub Actions |
-| [automergeNodeEnv.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for the Node.js environment |
-| [automergePreCommit.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for pre-commit |
-| [automergePyEnv.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for pyenv |
-| [automergePython.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for Python packages |
-| [automergeSchedule.json5](https://docs.renovatebot.com/configuration-options/#schedule) | Schedule settings for auto-merging |
-| [automergeStrategy.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Strategy settings for auto-merging |
-| [dependencyDashboard.json5](https://docs.renovatebot.com/configuration-options/#dependencydashboard) | Settings for the dependency dashboard |
-| [major.json5](https://docs.renovatebot.com/configuration-options/#major) | Settings for major updates |
-| [minor.json5](https://docs.renovatebot.com/configuration-options/#minor) | Settings for minor updates |
-| [patch.json5](https://docs.renovatebot.com/configuration-options/#patch) | Settings for patch updates |
-| [platformAutomerge.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Auto-merge settings for platforms |
-| [prHourlyLimit.json5](https://docs.renovatebot.com/configuration-options/#prhourlylimit) | Hourly limit settings for pull requests |
-| [schedule.json5](https://docs.renovatebot.com/configuration-options/#schedule) | Schedule settings |
-| [separateMajorMinor.json5](https://docs.renovatebot.com/configuration-options/#separatemajorminor) | Settings for separating major and minor updates |
-| [separateMultipleMajor.json5](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor) | Settings for separating multiple major updates |
-| [timezone.json5](https://docs.renovatebot.com/configuration-options/#timezone) | Time zone settings |
-| [vulnerabilityAlerts.json5](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts) | Vulnerability alert settings. This enables notifications if vulnerabilities are detected in dependencies. |
+| --------- | ----------- |
+| [default.json](./default.json) | Entry point for external repositories. Extends `renovate.json5`. |
+| [renovate.json5](./renovate.json5) | Main configuration file containing all Renovate settings. |
+
+### Main configuration options in `renovate.json5`
+
+| Option | Description |
+| ------ | ----------- |
+| `timezone` | Time zone setting (Asia/Tokyo) |
+| `schedule` | Update check schedule (weekends 0:00-6:00) |
+| `automerge` | Auto-merge settings for PRs |
+| `automergeSchedule` | Auto-merge schedule (weekdays 0:00-6:00) |
+| `automergeStrategy` | Merge strategy (squash) |
+| `platformAutomerge` | Enable platform-level auto-merge |
+| `separateMajorMinor` | Separate major and minor update PRs |
+| `dependencyDashboard` | Enable dependency dashboard |
+| `vulnerabilityAlerts` | Security vulnerability alert settings |
+| `packageRules` | Package-specific rules for GitHub Actions, Node.js, Python, etc. |
 
 ## Contribution
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -67,25 +67,24 @@ sequenceDiagram
 設定ファイルはリポジトリのルート以外では配置できません。
 
 | ファイル名 | 説明 |
-| ------------ | ------ |
-| [automergeGitHubActions.json5](https://docs.renovatebot.com/configuration-options/#automerge) | GitHub Actions の自動マージ設定 |
-| [automergeNodeEnv.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Node.js 環境の自動マージ設定 |
-| [automergePreCommit.json5](https://docs.renovatebot.com/configuration-options/#automerge) | pre-commit の自動マージ設定 |
-| [automergePyEnv.json5](https://docs.renovatebot.com/configuration-options/#automerge) | pyenv の自動マージ設定 |
-| [automergePython.json5](https://docs.renovatebot.com/configuration-options/#automerge) | Python パッケージの自動マージ設定 |
-| [automergeSchedule.json5](https://docs.renovatebot.com/configuration-options/#schedule) | 自動マージのスケジュール設定 |
-| [automergeStrategy.json5](https://docs.renovatebot.com/configuration-options/#automerge) | 自動マージの戦略設定 |
-| [dependencyDashboard.json5](https://docs.renovatebot.com/configuration-options/#dependencydashboard) | 依存関係ダッシュボードの設定 |
-| [major.json5](https://docs.renovatebot.com/configuration-options/#major) | メジャーアップデートの設定 |
-| [minor.json5](https://docs.renovatebot.com/configuration-options/#minor) | マイナーアップデートの設定 |
-| [patch.json5](https://docs.renovatebot.com/configuration-options/#patch) | パッチアップデートの設定 |
-| [platformAutomerge.json5](https://docs.renovatebot.com/configuration-options/#automerge) | プラットフォームの自動マージ設定 |
-| [prHourlyLimit.json5](https://docs.renovatebot.com/configuration-options/#prhourlylimit) | プルリクエストの時間あたりの制限設定 |
-| [schedule.json5](https://docs.renovatebot.com/configuration-options/#schedule) | スケジュール設定 |
-| [separateMajorMinor.json5](https://docs.renovatebot.com/configuration-options/#separatemajorminor) | メジャーとマイナーの分離設定 |
-| [separateMultipleMajor.json5](https://docs.renovatebot.com/configuration-options/#separatemultiplemajor) | 複数のメジャーアップデートの分離設定 |
-| [timezone.json5](https://docs.renovatebot.com/configuration-options/#timezone) | タイムゾーンの設定 |
-| [vulnerabilityAlerts.json5](https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts) | 脆弱性アラートの設定。これにより、依存関係に脆弱性が発見された場合に通知を受け取ることができます。 |
+| --------- | ----------- |
+| [default.json](../default.json) | 外部リポジトリ用のエントリーポイント。`renovate.json5` を extends します。 |
+| [renovate.json5](../renovate.json5) | すべての Renovate 設定を含むメイン設定ファイル。 |
+
+### `renovate.json5` の主要な設定項目
+
+| オプション | 説明 |
+| ------ | ----------- |
+| `timezone` | タイムゾーン設定 (Asia/Tokyo) |
+| `schedule` | 更新チェックのスケジュール (週末 0:00-6:00) |
+| `automerge` | PR の自動マージ設定 |
+| `automergeSchedule` | 自動マージのスケジュール (平日 0:00-6:00) |
+| `automergeStrategy` | マージ戦略 (squash) |
+| `platformAutomerge` | プラットフォームレベルの自動マージを有効化 |
+| `separateMajorMinor` | メジャーとマイナーの更新 PR を分離 |
+| `dependencyDashboard` | 依存関係ダッシュボードを有効化 |
+| `vulnerabilityAlerts` | セキュリティ脆弱性アラート設定 |
+| `packageRules` | GitHub Actions、Node.js、Python などのパッケージ固有ルール |
 
 ## 貢献方法
 


### PR DESCRIPTION

## 📒 変更概要

- `README.md`および`README.ja.md`において、Renovateの自動マージ設定に関する情報を更新しました。
- 主要な設定項目を追加し、設定内容をより明確にしました。

## ⚒ 技術的詳細

- 旧設定ファイルのリストを削除し、新たに`default.json`と`renovate.json5`の説明を追加しました。
- `renovate.json5`の主要な設定項目として、以下を追加しました:
  - `timezone`: タイムゾーン設定 (Asia/Tokyo)
  - `schedule`: 更新チェックのスケジュール (週末 0:00-6:00)
  - `automerge`: PR の自動マージ設定
  - `automergeSchedule`: 自動マージのスケジュール (平日 0:00-6:00)
  - `automergeStrategy`: マージ戦略 (squash)
  - `platformAutomerge`: プラットフォームレベルの自動マージを有効化
  - `separateMajorMinor`: メジャーとマイナーの更新 PR を分離
  - `dependencyDashboard`: 依存関係ダッシュボードを有効化
  - `vulnerabilityAlerts`: セキュリティ脆弱性アラート設定
  - `packageRules`: GitHub Actions、Node.js、Python などのパッケージ固有ルール

## ⚠ 注意点

- 💡 設定ファイルはリポジトリのルートに配置する必要があります。他の場所には配置できませんのでご注意ください。