### PR TITLE
🔧 Renovate設定にGitHub Actionのダイジェスト固定ヘルパーを追加

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,9 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended"],
+  extends: [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+  ],
   timezone: "Asia/Tokyo",
   schedule: ["after 0:00 before 6:00 every weekend"],
   automerge: true,


### PR DESCRIPTION

## 📒 変更概要

- 🛠 `renovate.json5`にGitHub Actionのダイジェストを固定するためのヘルパー`helpers:pinGitHubActionDigests`を追加しました。

## ⚒ 技術的詳細

- 🧩 `renovate.json5`の`extends`セクションに`helpers:pinGitHubActionDigests`を追加することで、GitHub Actionのバージョンをダイジェストで固定する設定を行いました。
- 🌐 これにより、GitHub Actionのバージョン管理がより安全かつ安定的になります。

## ⚠ 注意点

- 💡 この変更は、GitHub Actionのバージョンをダイジェストで固定するため、意図しないバージョンアップデートを防ぐことができますが、必要に応じて手動での更新が必要になる場合があります。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Renovate configuration to include an additional helper preset for enhanced GitHub Action digest pinning management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->